### PR TITLE
feat: add iOS app update endpoint

### DIFF
--- a/app/Http/Controllers/FestivalCompatController.php
+++ b/app/Http/Controllers/FestivalCompatController.php
@@ -209,6 +209,16 @@ class FestivalCompatController extends Controller
         ]);
     }
 
+    public function iosAppUpdate(): JsonResponse
+    {
+        return response()->json([
+            'data' => [
+                'force_update' => (bool) config('festival.ios_app_update.force_update', false),
+                'enable_closing' => (bool) config('festival.ios_app_update.enable_closing', false),
+            ],
+        ]);
+    }
+
     public function streamIndex(): JsonResponse
     {
         $schedule = LivestreamSchedule::query()

--- a/config/festival.php
+++ b/config/festival.php
@@ -29,4 +29,9 @@ return [
             'Momentan läuft kein Livestream. Komme bald wieder, um Dir den Livestream anzusehen.'
         ),
     ],
+
+    'ios_app_update' => [
+        'force_update' => env('FESTIVAL_IOS_FORCE_UPDATE', false),
+        'enable_closing' => env('FESTIVAL_IOS_FORCE_UPDATE_ENABLE_CLOSING', false),
+    ],
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,6 +93,10 @@ Route::group([
     Route::get('stream', [FestivalCompatController::class, 'streamIndex'])
         ->middleware('cache.headers:public;max_age=60;etag')
         ->name('stream.index');
+
+    Route::get('update/app/ios', [FestivalCompatController::class, 'iosAppUpdate'])
+        ->middleware('cache.headers:public;max_age=0;must_revalidate;etag')
+        ->name('update.app.ios');
 });
 
 Route::group([

--- a/tests/Feature/FestivalCompatibilityApiTest.php
+++ b/tests/Feature/FestivalCompatibilityApiTest.php
@@ -26,6 +26,38 @@ beforeEach(function () {
     ]);
 });
 
+test('festival ios app update endpoint returns disabled defaults', function () {
+    config([
+        'festival.ios_app_update.force_update' => false,
+        'festival.ios_app_update.enable_closing' => false,
+    ]);
+
+    getJson('/api/v1/festival/update/app/ios')
+        ->assertOk()
+        ->assertJson([
+            'data' => [
+                'force_update' => false,
+                'enable_closing' => false,
+            ],
+        ]);
+});
+
+test('festival ios app update endpoint returns configured force update values', function () {
+    config([
+        'festival.ios_app_update.force_update' => true,
+        'festival.ios_app_update.enable_closing' => true,
+    ]);
+
+    getJson('/api/v1/festival/update/app/ios')
+        ->assertOk()
+        ->assertJson([
+            'data' => [
+                'force_update' => true,
+                'enable_closing' => true,
+            ],
+        ]);
+});
+
 function createFestivalEvent(array $overrides = []): Event
 {
     $page = Page::factory()->published()->create([


### PR DESCRIPTION
## Summary
- add env-backed iOS app update config under festival.ios_app_update
- add GET /api/v1/festival/update/app/ios with force_update and enable_closing wrapped in data
- add Pest coverage for default false/false and configured true/true responses

## Verification
- git diff --check
- php artisan route:list --path=update/app/ios was verified in the main worktree

## Notes
- This is the server companion to LambdaDigamma/moers-ios#42.
- Targeted Pest execution is still blocked locally by the existing postgres host resolution issue.
